### PR TITLE
Bug fix: Replaced occurrences of setleds() with set_leds()

### DIFF
--- a/barrier/barrier.bzz
+++ b/barrier/barrier.bzz
@@ -25,7 +25,7 @@ function barrier_wait(threshold, transf) {
 
 # The final state
 function rgb_red() {
-  setleds(255,0,0)
+  set_leds(255,0,0)
   set_wheels(10.0,-10.0)
   #debug("red")
 }

--- a/gradient/gradient.bzz
+++ b/gradient/gradient.bzz
@@ -21,37 +21,37 @@ function step() {
   debug(mydist)
   # Added color gradient from red (closest) to blue (furthest)
   if(mydist < 100) {
-    setleds(255,0,0)
+    set_leds(255,0,0)
   }
   else if (mydist >= 100 and mydist < 200) {
-    setleds(255,102,0)
+    set_leds(255,102,0)
   }
   else if (mydist >= 200 and mydist < 300) {
-    setleds(255,204,0)
+    set_leds(255,204,0)
   }
     else if (mydist >= 300 and mydist < 400) {
-    setleds(204,255,0)
+    set_leds(204,255,0)
   }
     else if (mydist >= 400 and mydist < 500) {
-    setleds(101,255,0)
+    set_leds(101,255,0)
   }
     else if (mydist >= 500 and mydist < 600) {
-    setleds(0,255,0)
+    set_leds(0,255,0)
   }
     else if (mydist >= 600 and mydist < 700) {
-    setleds(0,255,101)
+    set_leds(0,255,101)
   }
     else if (mydist >= 700 and mydist < 800) {
-    setleds(0,255,203)
+    set_leds(0,255,203)
   }
     else if (mydist >= 800 and mydist < 900) {
-    setleds(0,203,255)
+    set_leds(0,203,255)
   }
     else if (mydist >= 900 and mydist < 1000) {
-    setleds(0,101,255)
+    set_leds(0,101,255)
   } 
     else  {
-    setleds(0,0,255)
+    set_leds(0,0,255)
   }
 
   # Set message to be passed every 3s

--- a/sync/sync.bzz
+++ b/sync/sync.bzz
@@ -48,9 +48,9 @@ function step() {
 	b = next_flash + FLASH_LENGTH
 
 	if(a < b) {
-		setleds(255,0,0)
+		set_leds(255,0,0)
 	} else {
-		setleds(0,0,0)
+		set_leds(0,0,0)
 	}
 
 	if(iteration > 50 and iteration % 10 == 0) {


### PR DESCRIPTION
The `setleds()` method does not exist, so causes some of the example code to crash. All instances of `setleds()` have been replaced with `set_leds()` to match the definition in https://github.com/MISTLab/Buzz/blob/master/src/buzz/argos/buzz_controller_footbot.cpp